### PR TITLE
Added functionality to decoding object

### DIFF
--- a/bson/codec.py
+++ b/bson/codec.py
@@ -89,8 +89,8 @@ def decode_object(raw_values):
 
 	retval = _EmptyClass()
 	retval.__class__ = cls
-	retval.bson_init(raw_values)
-	return retval
+	alt_retval = retval.bson_init(raw_values)
+	return alt_retval or retval
 
 # }}}
 # {{{ Codec Logic


### PR DESCRIPTION
Decoding objects assumes the object returned is of the type specified in the $$__CLASS_NAME__$$ item in the document. The commit requested to be pulled adds extensibility to this design by allowing a different object, possibly of a different type, be returned. This helps in certain cases, for example:
1. Proxy objects are serialized and deserialized, as may be done in cases where two incompatible data models need to be bridged by a compatible proxy data model.
2. Object instantiation has non-trivial side-effects that cannot be captured in bson_init() callback, e.g. database operations.
3. A cached version of the object being deserialized is preferred.
