### PR TITLE
Add optional on_unknown handler to bson.dumps

### DIFF
--- a/bson/__init__.py
+++ b/bson/__init__.py
@@ -56,7 +56,7 @@ import network
 __all__ = ["loads", "dumps"]
 
 # {{{ Serialization and Deserialization
-def dumps(obj, generator = None):
+def dumps(obj, generator = None, on_unknown = None):
 	"""
 	Given a dict, outputs a BSON string.
 
@@ -65,8 +65,8 @@ def dumps(obj, generator = None):
 	the correct encoding order for keys.
 	"""
 	if isinstance(obj, BSONCoding):
-		return encode_object(obj, [], generator_func = generator)
-	return encode_document(obj, [], generator_func = generator)
+		return encode_object(obj, [], generator_func = generator, on_unknown = on_unknown)
+	return encode_document(obj, [], generator_func = generator, on_unknown = on_unknown)
 
 def loads(data):
 	"""

--- a/bson/tests/test_unknown_handler.py
+++ b/bson/tests/test_unknown_handler.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+from bson import dumps, loads
+from decimal import Decimal
+from unittest import TestCase
+
+class TestUnknownHandler(TestCase):
+	def test_unknown_handler(self):
+		d = Decimal("123.45")
+		obj = {"decimal": d}
+
+		serialized = dumps(obj, on_unknown=float)
+		unserialized = loads(serialized)
+		self.assertEqual(float(d), unserialized["decimal"])


### PR DESCRIPTION
This PR adds an optional `on_unknown`-argument to `bson.dumps`, mirroring the functionality from `jsonlib`: https://pypi.python.org/pypi/jsonlib/1.3.10#serializing-other-types . In short, it allows converting unknown values to convertible values when dumping an object:

```python
bson.dumps({"val": Decimal("123.45")}, on_unknown=float)
```

This will dump the Decimal as float instead of `None` as is currently the case. If a `on_unknown`-argument is not provided and an unknown value encountered, a `UnknownSerializer`-exception is raised.