### PR TITLE
Fix cstring to check input for NUL bytes

### DIFF
--- a/bson/codec.py
+++ b/bson/codec.py
@@ -119,6 +119,10 @@ def decode_string(data, base):
 
 
 def encode_cstring(value):
+    if "\x00" in value:
+        raise ValueError("Element names may not include NUL bytes.")
+        # A NUL byte is used to delimit our string, accepting one would cause
+        # our string to terminate early.
     if isinstance(value, integer_types):
         value = str(value)
     if isinstance(value, text_type):


### PR DESCRIPTION
As per the spec, cstrings are not supposed to contain NUL bytes; py-bson lacked this check. As cstrings are terminated by NUL bytes, including them is quite hazardous, and leads to corruption of the BSON document. Depending on how an application uses py-bson, this may lead to security vulnerabilities.