### PR TITLE
fix encode_cstring for unicode strings in py2

### DIFF
--- a/bson/codec.py
+++ b/bson/codec.py
@@ -131,7 +131,7 @@ def encode_cstring(value):
         # our string to terminate early.
     if isinstance(value, integer_types):
         value = str(value)
-    if isinstance(value, text_type):
+    if not isinstance(value, bytes):
         value = value.encode("utf-8")
     return value + b"\x00"
 


### PR DESCRIPTION
Encoding an object to bson fails in py2 if the object is a `dict` with `unicode` keys:
```
  File "/Users/ryan.pessa/venv/ground-control/lib/python2.7/site-packages/bson/__init__.py", line 38, in dumps
    return encode_document(obj, [], generator_func=generator, on_unknown=on_unknown)
  File "/Users/ryan.pessa/venv/ground-control/lib/python2.7/site-packages/bson/codec.py", line 247, in encode_document
    encode_value(name, value, buf, traversal_stack, generator_func, on_unknown)
  File "/Users/ryan.pessa/venv/ground-control/lib/python2.7/site-packages/bson/codec.py", line 211, in encode_value
    buf.write(encode_string_element(name, value))
TypeError: 'unicode' does not have the buffer interface
```

This occurs because `encode_cstring()` checks if the value is an instance of `six.text_type`, which works fine on py3 - `text_type` is unicode, so unicode types will be encoded - but fails on py2 - `text_type` is bytes, so unicode types will not be encoded. Since the value remains as unicode, adding bytes results in a unicode object, and eventually `buf.write()` receives a unicode instead of bytes.

Note that there is no `unicode` in py3, so this checks if not `bytes` rather than checking if `unicode`.