### PR TITLE
Make bson faster

### DIFF
--- a/bson/codec.py
+++ b/bson/codec.py
@@ -272,7 +272,7 @@ def decode_document(data, base, as_array=False):
             value = b2a_hex(data[base:base + 12])
             base =+ 12
         elif element_type == 0x08:
-            value = not not struct.unpack("<b", data[base:base + 1])[0]
+            value = struct.unpack("<b", data[base:base + 1])[0]
         elif element_type == 0x09:
             value = datetime.fromtimestamp(
                 struct.unpack("<q", data[base:base + 8])[0] / 1000.0, pytz.utc)

--- a/bson/codec.py
+++ b/bson/codec.py
@@ -254,7 +254,7 @@ def encode_array(array, traversal_stack, traversal_parent = None, generator_func
     for i in xrange(0, len(array)):
         value = array[i]
         traversal_stack.append(TraversalStep(traversal_parent or array, i))
-        encode_value(text_type(i), value, buf, traversal_stack, generator_func, on_unknown)
+        encode_value(str(i), value, buf, traversal_stack, generator_func, on_unknown)
         traversal_stack.pop()
     e_list = buf.getvalue()
     e_list_length = len(e_list)

--- a/bson/codec.py
+++ b/bson/codec.py
@@ -129,8 +129,6 @@ def encode_cstring(value):
         raise ValueError("Element names may not include NUL bytes.")
         # A NUL byte is used to delimit our string, accepting one would cause
         # our string to terminate early.
-    if isinstance(value, integer_types):
-        value = str(value)
     if not isinstance(value, bytes):
         value = value.encode("utf-8")
     return value + b"\x00"

--- a/bson/codec.py
+++ b/bson/codec.py
@@ -131,12 +131,6 @@ def encode_binary(value):
     length = len(value)
     return struct.pack("<ib", length, 0) + value
 
-
-def decode_binary(data, base):
-    length, binary_type = struct.unpack("<ib", data[base:base + 5])
-    return base + 5 + length, data[base + 5:base + 5 + length]
-
-
 def encode_double(value):
     return struct.pack("<d", value)
 
@@ -271,7 +265,9 @@ def decode_document(data, base, as_array=False):
         elif element_type == 0x04:
             base, value = decode_document(data, base, as_array=True)
         elif element_type == 0x05:
-            base, value = decode_binary(data, base)
+            length, binary_type = struct.unpack("<ib", data[base:base + 5])
+            base += 5 + length
+            value = data[base + 5:base + 5 + length]
         elif element_type == 0x07:
             value = b2a_hex(data[base:base + 12])
             base =+ 12

--- a/bson/codec.py
+++ b/bson/codec.py
@@ -134,21 +134,20 @@ def encode_cstring(value):
     return value + b"\x00"
 
 
-def decode_cstring(data, base):
-    length = 0
-    max_length = len(data) - base
-    while length < max_length:
-        character = data[base + length]
-        if PY3:
-            character = chr(character)
-        length += 1
-        if character == "\x00":
-            break
-    # unicode() is faster in Python 2.
-    if PY3:
-        return base + length, data[base:base + length - 1].decode("utf-8")
-    else:
-        return  base + length, unicode(data[base:base + length - 1])
+def _p2_decode_cstring(data, base):
+    ll = data.index("\x00", base) + 1
+    return  ll, unicode(data[base:ll - 1])
+
+def _p3_decode_cstring(data, base):
+    ll = data.index(0, base) + 1
+    return ll, data[base:ll - 1].decode("utf-8")
+
+
+if PY3:
+    decode_cstring = _p3_decode_cstring
+else:
+    decode_cstring = _p2_decode_cstring
+
 
 def encode_binary(value):
     length = len(value)

--- a/bson/codec.py
+++ b/bson/codec.py
@@ -141,10 +141,6 @@ def encode_double(value):
     return struct.pack("<d", value)
 
 
-def decode_double(data, base):
-    return base + 8, struct.unpack("<d", data[base: base + 8])[0]
-
-
 ELEMENT_TYPES = {
     0x01: "double",
     0x02: "string",
@@ -260,7 +256,8 @@ def decode_document(data, base, as_array=False):
             base, name =  ll, unicode(data[base + 1:ll - 1]) if decode_name else None
 
         if element_type == 0x01:
-            base, value = decode_double(data, base)
+            value = struct.unpack("<d", data[base: base + 8])[0]
+            base += 8
         elif element_type == 0x02:
             length = struct.unpack("<i", data[base:base + 4])[0]
             value = data[base + 4: base + 4 + length - 1]

--- a/bson/codec.py
+++ b/bson/codec.py
@@ -174,6 +174,16 @@ def encode_double_element(name, value):
 def encode_string_element(name, value):
     return b"\x02" + encode_cstring(name) + encode_string(value)
 
+def _is_string(value):
+    if isinstance(value, text_type):
+        return True
+    elif isinstance(value, str) or isinstance(value, bytes):
+        try:
+            unicode(value, errors='strict')
+            return True
+        except:
+            pass
+    return False
 
 def encode_value(name, value, buf, traversal_stack, generator_func, on_unknown=None):
     if isinstance(value, integer_types):
@@ -186,7 +196,7 @@ def encode_value(name, value, buf, traversal_stack, generator_func, on_unknown=N
                 buf.write(encode_int32_element(name, value))
     elif isinstance(value, float):
         buf.write(encode_double_element(name, value))
-    elif isinstance(value, text_type):
+    elif _is_string(value):
         buf.write(encode_string_element(name, value))
     elif isinstance(value, str) or isinstance(value, bytes):
         buf.write(encode_binary_element(name, value))

--- a/bson/codec.py
+++ b/bson/codec.py
@@ -144,8 +144,11 @@ def decode_cstring(data, base):
         length += 1
         if character == "\x00":
             break
-    return base + length, data[base:base + length - 1].decode("utf-8")
-
+    # unicode() is faster in Python 2.
+    if PY3:
+        return base + length, data[base:base + length - 1].decode("utf-8")
+    else:
+        return  base + length, unicode(data[base:base + length - 1])
 
 def encode_binary(value):
     length = len(value)

--- a/bson/codec.py
+++ b/bson/codec.py
@@ -117,16 +117,6 @@ def encode_string(value):
     return struct.pack("<i%dsb" % (length,), length + 1, value, 0)
 
 
-def decode_string(data, base):
-    length = struct.unpack("<i", data[base:base + 4])[0]
-    value = data[base + 4: base + 4 + length - 1]
-    if PY3:
-        value = value.decode("utf-8")
-    else:
-        value = unicode(value)
-    return base + 4 + length, value
-
-
 def encode_cstring(value):
     if "\x00" in value:
         raise ValueError("Element names may not include NUL bytes.")
@@ -272,7 +262,13 @@ def decode_document(data, base, as_array=False):
         if element_type == 0x01:
             base, value = decode_double(data, base)
         elif element_type == 0x02:
-            base, value = decode_string(data, base)
+            length = struct.unpack("<i", data[base:base + 4])[0]
+            value = data[base + 4: base + 4 + length - 1]
+            if PY3:
+                value = value.decode("utf-8")
+            else:
+                value = unicode(value)
+            base += 4 + length
         elif element_type == 0x03:
             base, value = decode_document(data, base)
         elif element_type == 0x04:

--- a/bson/codec.py
+++ b/bson/codec.py
@@ -263,8 +263,7 @@ def encode_array(array, traversal_stack, traversal_parent = None, generator_func
 
 def decode_element(data, base):
     element_type = struct.unpack("<b", data[base:base + 1])[0]
-    element_description = ELEMENT_TYPES[element_type]
-    decode_func = globals()["decode_" + element_description + "_element"]
+    decode_func = _ELEMENT_TYPE_DECODERS[element_type]
     return decode_func(data, base)
 
 
@@ -382,3 +381,17 @@ def decode_object_id_element(data, base):
     base, name = decode_cstring(data, base + 1)
     value = b2a_hex(data[base:base + 12])
     return base + 12, name, value
+
+_ELEMENT_TYPE_DECODERS = {
+    0x01: decode_double_element,
+    0x02: decode_string_element,
+    0x03: decode_document_element,
+    0x04: decode_array_element,
+    0x05: decode_binary_element,
+    0x07: decode_object_id_element,
+    0x08: decode_boolean_element,
+    0x09: decode_UTCdatetime_element,
+    0x0A: decode_none_element,
+    0x10: decode_int32_element,
+    0x12: decode_int64_element
+}

--- a/bson/codec.py
+++ b/bson/codec.py
@@ -120,7 +120,10 @@ def encode_string(value):
 def decode_string(data, base):
     length = struct.unpack("<i", data[base:base + 4])[0]
     value = data[base + 4: base + 4 + length - 1]
-    value = value.decode("utf-8")
+    if PY3:
+        value = value.decode("utf-8")
+    else:
+        value = unicode(value)
     return base + 4 + length, value
 
 

--- a/bson/codec.py
+++ b/bson/codec.py
@@ -256,10 +256,10 @@ def decode_document(data, base, as_array=False):
             ll = data.index("\x00", base + 1) + 1
             base, name =  ll, unicode(data[base + 1:ll - 1]) if decode_name else None
 
-        if element_type == 0x01:
+        if element_type == 0x01: #  double
             value = double_struct.unpack(data[base: base + 8])[0]
             base += 8
-        elif element_type == 0x02:
+        elif element_type == 0x02: #  string
             length = int_struct.unpack(data[base:base + 4])[0]
             value = data[base + 4: base + 4 + length - 1]
             if PY3:
@@ -267,29 +267,29 @@ def decode_document(data, base, as_array=False):
             else:
                 value = unicode(value)
             base += 4 + length
-        elif element_type == 0x03:
+        elif element_type == 0x03: #  document
             base, value = decode_document(data, base)
-        elif element_type == 0x04:
+        elif element_type == 0x04: #  array
             base, value = decode_document(data, base, as_array=True)
-        elif element_type == 0x05:
+        elif element_type == 0x05: #  binary
             length, binary_type = int_char_struct.unpack(data[base:base + 5])
             base += 5 + length
             value = data[base + 5:base + 5 + length]
-        elif element_type == 0x07:
+        elif element_type == 0x07: #  object_id
             value = b2a_hex(data[base:base + 12])
             base =+ 12
-        elif element_type == 0x08:
+        elif element_type == 0x08: #  boolean
             value = char_struct.unpack(data[base:base + 1])[0]
-        elif element_type == 0x09:
+        elif element_type == 0x09: #  UTCdatetime
             value = datetime.fromtimestamp(
                 long_struct.unpack(data[base:base + 8])[0] / 1000.0, pytz.utc)
             base += 8
-        elif element_type == 0x0A:
+        elif element_type == 0x0A: #  none
             value = None
-        elif element_type == 0x10:
+        elif element_type == 0x10: #  int32
             value = int_struct.unpack(data[base:base + 4])[0]
             base += 4
-        elif element_type == 0x12:
+        elif element_type == 0x12: #  int64
             value = int_char_struct.unpack(data[base:base + 8])[0]
             base += 8
 


### PR DESCRIPTION
I've implemented a few (hacky) optimizations for this library here.
If you think any or all of them might be useful to merge back into py-bson
let me know and I can break them out into seperate PRs. 

Without optimizations:
('encode', 39.100188970565796)
('decode', 22.503355026245117)

With optimizations:
('encode', 19.88702392578125)
('decode', 5.7249510288238525)

These optimizations were found by running cProfile on this script.

```
import time
import bson

longs = [i for i in range(10000)]
floats = [float(i) for i in range(10000)]
str1 = ["abcdefghijklmnopqrstuvwxyz"]*10000
bools = [True]*10000
d = {"longs":longs,"strings":str1, "floats":floats, 'bools' : bools}

#warmup
for i in range(0, 100):
  a = bson.dumps(d)

for i in range(0, 100):
  b = bson.loads(a)


start_encode = time.time()
for i in range(0, 100):
  a = bson.dumps(d)
print ('encode', time.time() - start_encode)


a = bson.dumps(d)

start_decode = time.time()
for i in range(0, 100):
  b = bson.loads(a)
print ('decode', time.time() - start_decode)
```

#12 