### PR TITLE
consume booleans when parsing

### DIFF
--- a/bson/codec.py
+++ b/bson/codec.py
@@ -277,9 +277,10 @@ def decode_document(data, base, as_array=False):
             value = data[base + 5:base + 5 + length]
         elif element_type == 0x07: #  object_id
             value = b2a_hex(data[base:base + 12])
-            base =+ 12
+            base += 12
         elif element_type == 0x08: #  boolean
             value = char_struct.unpack(data[base:base + 1])[0]
+            base += 1
         elif element_type == 0x09: #  UTCdatetime
             value = datetime.fromtimestamp(
                 long_struct.unpack(data[base:base + 8])[0] / 1000.0, pytz.utc)


### PR DESCRIPTION
The `base` counter doesn't advance, and therefore doesn't consume the data, for boolean values. Fixed to advance the counter, also fixed apparent typo for object_id.