### PR TITLE
Fix encode_cstring integrity check

### DIFF
--- a/bson/codec.py
+++ b/bson/codec.py
@@ -118,7 +118,7 @@ def encode_string(value):
 
 
 def encode_cstring(value):
-    if isinstance(value, bytes):
+    if not isinstance(value, bytes):
             value = value.encode("utf-8")
     if "\x00" in value:
         raise ValueError("Element names may not include NUL bytes.")

--- a/bson/codec.py
+++ b/bson/codec.py
@@ -118,12 +118,12 @@ def encode_string(value):
 
 
 def encode_cstring(value):
+    if isinstance(value, bytes):
+            value = value.encode("utf-8")
     if "\x00" in value:
         raise ValueError("Element names may not include NUL bytes.")
         # A NUL byte is used to delimit our string, accepting one would cause
         # our string to terminate early.
-    if not isinstance(value, bytes):
-        value = value.encode("utf-8")
     return value + b"\x00"
 
 


### PR DESCRIPTION
Hey there,

A while ago I submitted a patch that fixed a bug in encode_cstring allowing cstrings to contain NUL bytes, corrupting the document. For those who aren't aware, the name "cstring" is misleading. These are not ASCII strings, they are NUL-delimited UTF-8 strings without a length parameter. This has the potential to impact security.

The issue this time was that the NUL check was performed before the string was encoded. The NULs are not present until the string is encoded. I've moved the encoding to the top of the function.

Cheers,
xmnr