### PR TITLE
Fixed exception in encode_cstring with Python3

### DIFF
--- a/bson/codec.py
+++ b/bson/codec.py
@@ -120,7 +120,7 @@ def encode_string(value):
 def encode_cstring(value):
     if not isinstance(value, bytes):
             value = value.encode("utf-8")
-    if "\x00" in value:
+    if b"\x00" in value:
         raise ValueError("Element names may not include NUL bytes.")
         # A NUL byte is used to delimit our string, accepting one would cause
         # our string to terminate early.


### PR DESCRIPTION
I pulled today and noticed the tests fail when run with Python3; the recent change to move the NUL check introduced this I believe. 

```
Python 3.5.2+ (default, Sep 22 2016, 12:18:14)                                                 
[GCC 6.2.0 20160927] on linux                                                                  
Type "help", "copyright", "credits" or "license" for more information.                         
>>> import bson                                                                                
>>> bson.dumps({"foo":1})                                                                      
Traceback (most recent call last):                                                             
  File "<stdin>", line 1, in <module>                                                          
  File "/home/dnoor/clients/python/tests/lib/bson/__init__.py", line 38, in dumps              
    return encode_document(obj, [], generator_func=generator, on_unknown=on_unknown)           
  File "/home/dnoor/clients/python/tests/lib/bson/codec.py", line 213, in encode_document      
    encode_value(name, value, buf, traversal_stack, generator_func, on_unknown)                
  File "/home/dnoor/clients/python/tests/lib/bson/codec.py", line 179, in encode_value         
    buf.write(encode_int32_element(name, value))                                               
  File "/home/dnoor/clients/python/tests/lib/bson/codec.py", line 335, in encode_int32_element 
    return b"\x10" + encode_cstring(name) + value                                              
  File "/home/dnoor/clients/python/tests/lib/bson/codec.py", line 123, in encode_cstring       
    if "\x00" in value:                                                                        
TypeError: a bytes-like object is required, not 'str'                                          
>>>                                                                                            
```


I think this one-character fix addresses the code issue and I've manually ran tests on python2 and python3. but I'm not familiar enough with the project to make sure both python2 and python3 are covered by the project's automated testing.