### PR TITLE
Add support for UUID binary subtype

### DIFF
--- a/bson/codec.py
+++ b/bson/codec.py
@@ -251,7 +251,7 @@ def encode_array(array, traversal_stack, traversal_parent=None,
 
 
 def decode_binary_subtype(value, binary_subtype):
-    if binary_subtype == 0x04: # UUID
+    if binary_subtype in [0x03, 0x04]: # legacy UUID, UUID
         return UUID(bytes=value)
     return value
 

--- a/bson/codec.py
+++ b/bson/codec.py
@@ -10,6 +10,7 @@ import struct
 import warnings
 from datetime import datetime
 from abc import ABCMeta, abstractmethod
+from uuid import UUID
 try:
     from io import BytesIO as StringIO
 except ImportError:
@@ -131,9 +132,9 @@ def encode_cstring(value):
     return value + b"\x00"
 
 
-def encode_binary(value):
+def encode_binary(value, binary_subtype=0):
     length = len(value)
-    return struct.pack("<ib", length, 0) + value
+    return struct.pack("<ib", length, binary_subtype) + value
 
 
 def encode_double(value):
@@ -191,6 +192,8 @@ def encode_value(name, value, buf, traversal_stack,
         buf.write(encode_string_element(name, value))
     elif isinstance(value, str) or isinstance(value, bytes):
         buf.write(encode_binary_element(name, value))
+    elif isinstance(value, UUID):
+        buf.write(encode_binary_element(name, value.bytes, binary_subtype=4))
     elif isinstance(value, bool):
         buf.write(encode_boolean_element(name, value))
     elif isinstance(value, datetime):
@@ -247,6 +250,12 @@ def encode_array(array, traversal_stack, traversal_parent=None,
                        e_list_length + 4 + 1, e_list, 0)
 
 
+def decode_binary_subtype(value, binary_subtype):
+    if binary_subtype == 0x04: # UUID
+        return UUID(bytes=value)
+    return value
+
+
 def decode_document(data, base, as_array=False):
     # Create all the struct formats we might use.
     double_struct = struct.Struct("<d")
@@ -292,8 +301,9 @@ def decode_document(data, base, as_array=False):
         elif element_type == 0x04:  # array
             base, value = decode_document(data, base, as_array=True)
         elif element_type == 0x05:  # binary
-            length, binary_type = int_char_struct.unpack(data[base:base + 5])
+            length, binary_subtype = int_char_struct.unpack(data[base:base + 5])
             value = data[base + 5:base + 5 + length]
+            value = decode_binary_subtype(value, binary_subtype)
             base += 5 + length
         elif element_type == 0x07:  # object_id
             value = b2a_hex(data[base:base + 12])
@@ -337,8 +347,8 @@ def encode_array_element(name, value, traversal_stack,
                         generator_func=generator_func, on_unknown=on_unknown)
 
 
-def encode_binary_element(name, value):
-    return b"\x05" + encode_cstring(name) + encode_binary(value)
+def encode_binary_element(name, value, binary_subtype=0):
+    return b"\x05" + encode_cstring(name) + encode_binary(value, binary_subtype=binary_subtype)
 
 
 def encode_boolean_element(name, value):

--- a/bson/tests/test_uuid.py
+++ b/bson/tests/test_uuid.py
@@ -15,3 +15,11 @@ class TestUUID(TestCase):
 
         self.assertIsInstance(obj2['uuid'], UUID)
         self.assertTrue(obj2['uuid'] == uuid)
+
+    def test_legacy_uuid(self):
+        uuid = UUID('584bcd8f-6d81-485a-bac9-629c14b53847')
+        serialized = b' \x00\x00\x00\x05uuid\x00\x10\x00\x00\x00\x03XK\xcd\x8fm\x81HZ\xba\xc9b\x9c\x14\xb58G\x00'
+        obj = loads(serialized)
+
+        self.assertIsInstance(obj['uuid'], UUID)
+        self.assertTrue(obj['uuid'] == uuid)

--- a/bson/tests/test_uuid.py
+++ b/bson/tests/test_uuid.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+from uuid import UUID
+
+from unittest import TestCase
+
+from bson import dumps, loads
+
+
+class TestUUID(TestCase):
+    def test_uuid(self):
+        uuid = UUID('584bcd8f-6d81-485a-bac9-629c14b53847')
+        obj = {"uuid": uuid}
+        serialized = dumps(obj)
+        obj2 = loads(serialized)
+
+        self.assertIsInstance(obj2['uuid'], UUID)
+        self.assertTrue(obj2['uuid'] == uuid)


### PR DESCRIPTION
This duplicates the UUID object handling behavior of the pymongo bson implementation:

```pycon
>>> # pymongo
>>> from uuid import UUID
>>> from bson import BSON
>>> uuid = UUID('584bcd8f-6d81-485a-bac9-629c14b53847')
>>> doc1 = BSON.encode({'uuid': uuid})
>>> doc1
b' \x00\x00\x00\x05uuid\x00\x10\x00\x00\x00\x03XK\xcd\x8fm\x81HZ\xba\xc9b\x9c\x14\xb58G\x00'
>>> BSON.decode(doc1)
{'uuid': UUID('584bcd8f-6d81-485a-bac9-629c14b53847')}
>>> # bson
>>> import bson
>>> doc2 = bson.dumps({'uuid': uuid})
>>> doc2
b' \x00\x00\x00\x05uuid\x00\x10\x00\x00\x00\x04XK\xcd\x8fm\x81HZ\xba\xc9b\x9c\x14\xb58G\x00'
>>> doc1 == doc2 # type 0x03 vs 0x04
False
>>> bson.loads(doc2)
{'uuid': UUID('584bcd8f-6d81-485a-bac9-629c14b53847')}
>>> # interchangeable
>>> BSON.decode(doc2)
{'uuid': UUID('584bcd8f-6d81-485a-bac9-629c14b53847')}
>>> bson.loads(doc1)
{'uuid': UUID('584bcd8f-6d81-485a-bac9-629c14b53847')}
```

The pymongo implementation still uses `0x03` while serializing, these appear to be interchangeable, and the specification suggests `0x04` should be preferred.