### PR TITLE
Fixed serialization/deserialization of bool type

### DIFF
--- a/bson/codec.py
+++ b/bson/codec.py
@@ -178,7 +178,7 @@ def _is_string(value):
 
 def encode_value(name, value, buf, traversal_stack,
                  generator_func, on_unknown=None):
-    if isinstance(value, integer_types):
+    if isinstance(value, integer_types) is not isinstance(value, bool):
         if not PY3 and isinstance(value, long):
             buf.write(encode_int64_element(name, value))
         else:
@@ -309,7 +309,7 @@ def decode_document(data, base, as_array=False):
             value = b2a_hex(data[base:base + 12])
             base += 12
         elif element_type == 0x08:  # boolean
-            value = char_struct.unpack(data[base:base + 1])[0]
+            value = bool(char_struct.unpack(data[base:base + 1])[0])
             base += 1
         elif element_type == 0x09:  # UTCdatetime
             value = datetime.fromtimestamp(

--- a/bson/tests/test_boolean.py
+++ b/bson/tests/test_boolean.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+from unittest import TestCase
+
+import bson
+
+
+class TestBoolean(TestCase):
+    def test_false_value(self):
+        data = {"key": False}
+        serialized = bson.dumps(data)
+        deserialized = bson.loads(serialized)
+
+        self.assertIsInstance(deserialized["key"], bool)
+        self.assertFalse(deserialized["key"])
+        self.assertTrue(serialized == b'\x0b\x00\x00\x00\x08key\x00\x00\x00')
+
+    def test_true_value(self):
+        data = {"key": True}
+        serialized = bson.dumps(data)
+        deserialized = bson.loads(serialized)
+
+        self.assertIsInstance(deserialized["key"], bool)
+        self.assertTrue(deserialized["key"])
+        self.assertTrue(serialized == b'\x0b\x00\x00\x00\x08key\x00\x01\x00')


### PR DESCRIPTION
The library couldn't serialize and deserialize boolean type as
bool because of one wrong condition in codec.py
(isinstance(bool(), int) return True). In that patch the condition
has been modified to resolve that issue.

Also the patch contains a couple of tests which check if
boolean serialization/deserialization work correct.