### PR TITLE
Fix UnicodeDecodeError for Chinese

### DIFF
--- a/bson/codec.py
+++ b/bson/codec.py
@@ -19,6 +19,7 @@ except ImportError:
 
 import calendar
 import pytz
+from CodeConvert import CodeConvert as cc
 from binascii import b2a_hex
 
 from six import integer_types, iterkeys, text_type, PY3
@@ -303,7 +304,7 @@ def decode_document(data, base, as_array=False):
             if PY3:
                 value = value.decode("utf-8")
             else:
-                value = unicode(value)
+                value = cc.Convert2Unicode(value)
             base += 4 + length
         elif element_type == 0x03:  # document
             base, value = decode_document(data, base)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     name="bson",
     version="0.5.2",
     packages=["bson"],
-    install_requires=["pytz>=2010b", "six>=1.9.0"],
+    install_requires=["CodeConvert>=2.0.4", "pytz>=2010b", "six>=1.9.0"],
     author="Ayun Park",
     author_email="iamparkayun@gmail.com",
     description="BSON codec for Python",


### PR DESCRIPTION
```python
ipdb> value
'\xe8\xa5\xbf\xe6\xb1\x89\xe6\x96\x87\xe5\xad\xa6\xe6\x88\x90\xe5\xb0\xb1\xe4\xb8\xad\xef\xbc\x8c\xe6\x9c\x80\xe4\xb8\xba\xe7\xaa\x81\xe5\x87\xba\xe7\x9a\x84\xe6\x98\xaf\xef\xbc\x9f'
ipdb> unicode(value)
*** UnicodeDecodeError: 'ascii' codec can't decode byte 0xe8 in position 0: ordinal not in range(128)
ipdb> cc.Convert2Unicode(value)

u'\u897f\u6c49\u6587\u5b66\u6210\u5c31\u4e2d\uff0c\u6700\u4e3a\u7a81\u51fa\u7684\u662f\uff1f'
ipdb> print cc.Convert2Unicode(value)

西汉文学成就中，最为突出的是？
ipdb>
```