### PR TITLE
Depend on pip as there is an import from it on the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,6 @@
 # For licensing, see LICENSE file included in the package.
 import sys
 
-try:
-    from pip._internal import get_installed_distributions
-except ImportError:
-    from pip import get_installed_distributions
-
 from setuptools import setup
 from setuptools.command.install import install
 
@@ -18,6 +13,10 @@ class NewInstall(install):
 
     @staticmethod
     def check_pymongo():
+        try:
+            from pip._internal import get_installed_distributions
+        except ImportError:
+            from pip import get_installed_distributions
         for package in get_installed_distributions():
             if package.project_name == 'pymongo':
                 return True
@@ -31,9 +30,9 @@ class NewInstall(install):
 
 setup(
     name="bson",
-    version="0.5.3",
+    version="0.5.4",
     packages=["bson"],
-    install_requires=["pytz>=2010b", "six>=1.9.0"],
+    install_requires=["pytz>=2010b", "six>=1.9.0", "pip>=1.0"],
     author="Ayun Park",
     author_email="iamparkayun@gmail.com",
     description="BSON codec for Python",


### PR DESCRIPTION
I'm running a Gentoo distribution which does not have `pip` installed by default. [In Gentoo, apparently](https://wiki.gentoo.org/wiki/Pip), you either use `portage`, its package manager or `pip` for the Python packages.

By default there is no `pip`. So in order to pull the dependency of pip... well, it needs to be declared a dependency. And in order for that to work, the import of the `get_installed_distributions` function needs to be done after installing the dependency `pip` is fulfilled.