### PR TITLE
Fixed compability with newer pip versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2015, Ayun Park. All rights reserved.
 # For licensing, see LICENSE file included in the package.
 import sys
-
+import pkgutil
 from setuptools import setup
 from setuptools.command.install import install
 
@@ -13,13 +13,8 @@ class NewInstall(install):
 
     @staticmethod
     def check_pymongo():
-        try:
-            from pip._internal import get_installed_distributions
-        except ImportError:
-            from pip import get_installed_distributions
-        for package in get_installed_distributions():
-            if package.project_name == 'pymongo':
-                return True
+        if pkgutil.find_loader('pymongo'):
+            return True
         return False
 
     def run(self):

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     name="bson",
     version="0.5.4",
     packages=["bson"],
-    install_requires=["pytz>=2010b", "six>=1.9.0", "pip>=1.0"],
+    install_requires=["pytz>=2010b", "six>=1.9.0"],
     author="Ayun Park",
     author_email="iamparkayun@gmail.com",
     description="BSON codec for Python",


### PR DESCRIPTION
#77 #81 #77 
Improvement works both in Python 2.x and 3.x
Based on [Announcement: Pip 10 is coming, and will move all internal APIs](https://mail.python.org/pipermail/distutils-sig/2017-October/031642.html)