### PR TITLE
Switch from pytz to python-dateutil

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 - 3.5
 - 3.6
 install:
-- pip install pytz>=2010b six>=1.9.0
+- pip install python-dateutil>=2.4.0 six>=1.9.0
 - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install unittest2; fi
 script:
 - python test.py

--- a/bson/codec.py
+++ b/bson/codec.py
@@ -18,12 +18,14 @@ except ImportError:
     from cStringIO import StringIO
 
 import calendar
-import pytz
+from dateutil.tz import tzutc
 from binascii import b2a_hex
 
 from six import integer_types, iterkeys, text_type, PY3
 from six.moves import xrange
 
+
+utc = tzutc()
 
 class MissingClassDefinition(ValueError):
     def __init__(self, class_name):
@@ -320,7 +322,7 @@ def decode_document(data, base, as_array=False):
             base += 1
         elif element_type == 0x09:  # UTCdatetime
             value = datetime.fromtimestamp(
-                long_struct.unpack(data[base:base + 8])[0] / 1000.0, pytz.utc)
+                long_struct.unpack(data[base:base + 8])[0] / 1000.0, utc)
             base += 8
         elif element_type == 0x0A:  # none
             value = None

--- a/bson/tests/test_datetime.py
+++ b/bson/tests/test_datetime.py
@@ -2,13 +2,13 @@
 from datetime import datetime
 from unittest import TestCase
 
-import pytz
+from dateutil.tz import tzutc
 from bson import dumps, loads
 
 
 class TestDateTime(TestCase):
     def test_datetime(self):
-        now = datetime.now(pytz.utc)
+        now = datetime.now(tzutc())
         obj = {"now": now}
         serialized = dumps(obj)
         obj2 = loads(serialized)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     name="bson",
     version="0.5.4",
     packages=["bson"],
-    install_requires=["pytz>=2010b", "six>=1.9.0", "pip>=1.0"],
+    install_requires=["python-dateutil>=2.4.0", "six>=1.9.0", "pip>=1.0"],
     author="Ayun Park",
     author_email="iamparkayun@gmail.com",
     description="BSON codec for Python",


### PR DESCRIPTION
For multiple reasons:

- `dateutil` is smaller because it uses native tzdata of each OS (event Windows), while pytz ships tzdata

- `pytz` is generally not safe unless you are careful how you use it. Read: https://blog.ganssle.io/articles/2018/03/pytz-fastest-footgun.html

- `dateutil` has more active development (check [Github](https://github.com/dateutil/dateutil/graphs/contributors) and [pypi](https://pypi.org/project/python-dateutil/2.7.2/#history))

- `dateutil` has more functionality than just timezone.
