### PR TITLE
Ability to deal with binary keys that are not UTF8

### DIFF
--- a/bson/codec.py
+++ b/bson/codec.py
@@ -286,12 +286,20 @@ def decode_document(data, base, as_array=False):
 
         if PY3:
             ll = data.index(0, base + 1) + 1
-            base, name = ll, data[base + 1:ll - 1].decode("utf-8") \
-                if decode_name else None
+            try:
+                base, name = ll, data[base + 1:ll - 1].decode("utf-8") \
+                    if decode_name else None
+            except UnicodeDecodeError:
+                base, name = ll, data[base + 1:ll - 1] \
+                    if decode_name else None
         else:
             ll = data.index("\x00", base + 1) + 1
-            base, name = ll, unicode(data[base + 1:ll - 1])\
-                if decode_name else None
+            try:
+                base, name = ll, unicode(data[base + 1:ll - 1])\
+                    if decode_name else None
+            except UnicodeDecodeError:
+                base, name = ll, data[base + 1:ll - 1]\
+                    if decode_name else None
 
         if element_type == 0x01:  # double
             value = double_struct.unpack(data[base: base + 8])[0]

--- a/bson/tests/test_non_utf8_binary.py
+++ b/bson/tests/test_non_utf8_binary.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+from unittest import TestCase
+
+from bson import dumps, loads
+
+
+class TestNonUtf8Binary(TestCase):
+    def setUp(self):
+        self.doc = {b'\x88': None}
+
+    def test_non_utf8_binary(self):
+        dump = dumps(self.doc)
+        decoded = loads(dump)
+        self.assertEqual(decoded, self.doc)


### PR DESCRIPTION
I'm not sure if this is the proper way to fix it, but at least tests go through and it seems to work.

I also wrote a new test that introduces a simplified version of a case I was having problems with.