### PR TITLE
Fix UTF-8 encoding/decoding on Python 2

### DIFF
--- a/bson/tests/test_binary.py
+++ b/bson/tests/test_binary.py
@@ -52,3 +52,7 @@ class TestBinary(TestCase):
         dump = dumps(self.doc)
         decoded = loads(dump)
         self.assertEqual(decoded, self.doc)
+
+    def test_utf8_binary(self):
+        self.doc[u"\N{SNOWMAN}"] = u"\N{SNOWMAN WITHOUT SNOW}"
+        self.test_binary()


### PR DESCRIPTION
This fixes encoding of non-ASCII names, and decoding of non-ASCII names
and values.

Fixes #97.