### PR TITLE
Add fixed width integers: Int32, Int64 and UInt64

### DIFF
--- a/bson/codec.py
+++ b/bson/codec.py
@@ -12,6 +12,9 @@ from datetime import datetime
 from abc import ABCMeta, abstractmethod
 from uuid import UUID
 from decimal import Decimal
+
+from bson.types import UInt64, Int64, Int32
+
 try:
     from io import BytesIO as StringIO
 except ImportError:
@@ -195,6 +198,12 @@ def encode_value(name, value, buf, traversal_stack,
             buf.write(encode_uint64_element(name, value))
         else:
             buf.write(encode_int32_element(name, value))
+    elif isinstance(value, Int32):
+        buf.write(encode_int32_element(name, value.get_value()))
+    elif isinstance(value, Int64):
+        buf.write(encode_int64_element(name, value.get_value()))
+    elif isinstance(value, UInt64):
+        buf.write(encode_uint64_element(name, value.get_value()))
     elif isinstance(value, float):
         buf.write(encode_double_element(name, value))
     elif _is_string(value):

--- a/bson/tests/test_types.py
+++ b/bson/tests/test_types.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+from unittest import TestCase
+
+from bson import dumps, loads
+from bson.types import UInt64, Int64, Int32
+
+
+class TestTypes(TestCase):
+    def setUp(self):
+        self.good_request_dict = {
+            "uint64": UInt64(0xFFFFFFFFFFFFFFFF - 1),
+            "int64": Int64(0x7FFFFFFFFFFFFFFF - 1),
+            "int32": Int32(0x7fffffff)
+        }
+
+    def test_bad_values(self):
+        with self.assertRaises(ValueError):
+            UInt64(0xFFFFFFFFFFFFFFFF << 1)
+        with self.assertRaises(ValueError):
+            Int32(2**32)
+        with self.assertRaises(ValueError):
+            Int64(2**64)
+        with self.assertRaises(ValueError):
+            Int32(-2**31-1)
+        with self.assertRaises(ValueError):
+            Int64(-2**63-1)
+
+    def test_int(self):
+        dump = dumps(self.good_request_dict)
+        decoded = loads(dump)
+        self.assertEqual(decoded, {k: v.get_value() for k, v in self.good_request_dict.items()})
+

--- a/bson/types.py
+++ b/bson/types.py
@@ -1,6 +1,6 @@
 class Int32:
     """
-    An signed integer with a 32-bit fixed width.
+    A signed integer with a 32-bit fixed width.
     """
 
     def __init__(self, value):
@@ -17,7 +17,7 @@ class Int32:
 
 class Int64:
     """
-    An signed integer with a 64-bit fixed width.
+    A signed integer with a 64-bit fixed width.
     """
 
     def __init__(self, value):

--- a/bson/types.py
+++ b/bson/types.py
@@ -1,0 +1,49 @@
+class Int32:
+    """
+    An signed integer with a 32-bit fixed width.
+    """
+
+    def __init__(self, value):
+        if value < -2 ** 31 or value > 2 ** 31 - 1:
+            raise ValueError('value {} cannot be represented in int32'.format(value))
+        self._value = value
+
+    def get_value(self):
+        return self._value
+
+    def __str__(self):
+        return str(self._value)
+
+
+class Int64:
+    """
+    An signed integer with a 64-bit fixed width.
+    """
+
+    def __init__(self, value):
+        if value < -2 ** 63 or value > 2 ** 63 - 1:
+            raise ValueError('value {} cannot be represented in int32'.format(value))
+        self._value = value
+
+    def get_value(self):
+        return self._value
+
+    def __str__(self):
+        return str(self._value)
+
+
+class UInt64:
+    """
+    An unsigned integer with a 64-bit fixed width.
+    """
+
+    def __init__(self, value):
+        if value < 0 or value > 2 ** 64 - 1:
+            raise ValueError('value {} cannot be represented in uint32'.format(value))
+        self._value = value
+
+    def get_value(self):
+        return self._value
+
+    def __str__(self):
+        return str(self._value)


### PR DESCRIPTION
Since Python's has only one integer type `int`, constructing BSON with some fixed-width integer values is difficult.
I added file `bson.types` to solve this problem. It contains three wrapped integer: Int32, Int64 and UInt64, which are able to be encoded in their corresponding width by `bson.dumps` method.

Example usage:
```
from bson.types import Int64

a = bson.dumps({
            'time': Int64(112233)
})
```
which will encode `time` as a 64-bit integer (`\x12`):
```
b'\x13\x00\x00\x00\x12time\x00i\xb6\x01\x00\x00\x00\x00\x00\x00'
```

The decode process is unmodified. They will be decoded as Python's int.