### PR TITLE
fix return for numpy arrays

### DIFF
--- a/pybson/codec.py
+++ b/pybson/codec.py
@@ -118,7 +118,7 @@ def decode_object(raw_values):
     retval = _EmptyClass()
     retval.__class__ = cls
     alt_retval = retval.bson_init(raw_values)
-    return alt_retval or retval
+    return retval if alt_retval is None else alt_retval
 
 
 def encode_string(value):


### PR DESCRIPTION
numpy arrays can now be returned from BSONCoding.bson_init(raw_values)

[example.zip](https://github.com/py-bson/bson/files/6801132/example.zip)
