### PR TITLE
Fix a year 2038 issue

### DIFF
--- a/bson/objectid.py
+++ b/bson/objectid.py
@@ -158,7 +158,7 @@ class ObjectId(object):
             generation_time = generation_time - generation_time.utcoffset()
         timestamp = calendar.timegm(generation_time.timetuple())
         oid = struct.pack(
-            ">i", int(timestamp)) + b"\x00\x00\x00\x00\x00\x00\x00\x00"
+            ">L", int(timestamp) & 0xFFFFFFFF) + b"\x00\x00\x00\x00\x00\x00\x00\x00"
         return cls(oid)
 
     @classmethod
@@ -184,7 +184,7 @@ class ObjectId(object):
         """
 
         # 4 bytes current time
-        oid = struct.pack(">i", int(time.time()))
+        oid = struct.pack(">L", int(time.time()) & 0xFFFFFFFF)
 
         # 3 bytes machine
         oid += ObjectId._machine_bytes

--- a/bson/tests/test_objectid.py
+++ b/bson/tests/test_objectid.py
@@ -522,7 +522,7 @@ class TestObjectId(unittest.TestCase):
         if 'PyPy 1.8.0' in sys.version:
             # See https://bugs.pypy.org/issue1092
             raise SkipTest("datetime.timedelta is broken in pypy 1.8.0")
-        d = datetime.datetime.utcnow()
+        d = datetime.datetime.utcfromtimestamp(2000000000)
         d = d - datetime.timedelta(microseconds=d.microsecond)
         oid = ObjectId.from_datetime(d)
         self.assertEqual(d, oid.generation_time.replace(tzinfo=None))


### PR DESCRIPTION
This bug was found while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).


Background:
As part of my work on reproducible builds for openSUSE, I check that software still gives identical build results in the future.
The usual offset is +16 years, because that is how long I expect some software will be used in some places.
This showed up failing tests in our package build.
See https://reproducible-builds.org/ for why this matters.